### PR TITLE
bug fix for adding upstream trigger

### DIFF
--- a/add_upstreamjob.groovy
+++ b/add_upstreamjob.groovy
@@ -12,6 +12,10 @@ def addUpstream(upstreamJob){
    def exisitngTrigger
    for (line in linesR){
      linenum++
+     if(line=~ /^\s+.*pipelineTriggers\(\[upstream.*/){
+        println "Upstream job trigger already present"
+        return this
+     }
      if(line=~ /^\s+pipelineTriggers\(\[(.*)\]\)/){
         insert_append=linenum
         (line=~ /^\s+pipelineTriggers\(\[(.*)\]\)/).each {match -> exisitngTrigger=match[1] }


### PR DESCRIPTION
Signed-off-by: Prajwal Gowda <pgowda@itemis.de>
fixes : pipelineTriggers added twice for xtext-eclipse
if there is already a upstream job trigger present in the Jenkinsfile then it will skip adding.